### PR TITLE
improvements: new DateTime requirements

### DIFF
--- a/src/components/DatePickerInline/Day.tsx
+++ b/src/components/DatePickerInline/Day.tsx
@@ -52,11 +52,7 @@ function Day(props: {
         },
     );
     const onPress = useCallback(() => {
-        const date = new Date(year, month, day);
-        date.setHours(0);
-        date.setMinutes(0);
-        date.setSeconds(0);
-        onPressDate(date);
+        onPressDate(new Date(year, month, day));
     }, [onPressDate, year, month, day]);
 
     const { containerStyle, buttonStyle, dayStyle, textStyle } = useMemo(() => {

--- a/src/components/DateTimePicker/DateTimePicker.tsx
+++ b/src/components/DateTimePicker/DateTimePicker.tsx
@@ -21,6 +21,16 @@ export type Props = ViewProps & {
 
 const emptyObj = {};
 
+const normalizeDateWithCurrentTime = (specificDate: Date) => {
+    const date = new Date();
+
+    date.setFullYear(specificDate.getFullYear());
+    date.setMonth(specificDate.getMonth());
+    date.setDate(specificDate.getDate());
+
+    return date;
+};
+
 const DateTimePicker = (
     {
         is24Hour = false,
@@ -55,7 +65,7 @@ const DateTimePicker = (
             }
 
             if (!date) {
-                onChange(newDate);
+                onChange(normalizeDateWithCurrentTime(newDate));
                 return;
             }
 


### PR DESCRIPTION
We have three specific cases regarding Date type fields:

1) If a Date type field includes a time that is unspecified, it should display the current user's local time.
2) When a Date type field doesn't include a time, it should default to 0:00. Any modifications should be based on the server's time.
3) If a Date type field initially lacks a specified time and a time option is subsequently added, it should display as 0:00. 
[time-fix.webm](https://github.com/webbeetechnologies/bamboo-molecules/assets/28690701/59910c56-d1b3-4d5f-85c4-5c33c0d27064)

